### PR TITLE
show the demo graph in the demo page

### DIFF
--- a/crawler_app/crawler_app/templates/demo/index.pt
+++ b/crawler_app/crawler_app/templates/demo/index.pt
@@ -2,6 +2,7 @@
 
   <div metal:fill-slot="additional_css">
   <link href="/static/css/bokeh-0.12.13.min.css" rel="stylesheet">
+  <link href="/static/css/d3_css.css" rel="stylesheet">
   </div>
 
   <div metal:fill-slot="navigation">
@@ -75,10 +76,17 @@
               The representation of the demo graph using our visualization convention can be found at <a class="nav-link text-uppercase text-expanded" href="/search/demo">https://www.caelum.site/search/demo</a>
               </p>
 
-              <p>Note how the root node0 encapsulates every other node. On the first level we see three smaller circles. These represent node1, 2 and 3. Node2 contains nodes 4 and 5, node 3 contains the node6 which in turn contains nodes down the tree. We see that leaf nodes (nodes with no children) are white while nodes at each level are colored similarly. Clicking down a path of nodes allows the user to clearly see the currently selected node (displayed as a link to that page above graph) as well as the ability to hover over nodes one level up or one level down from the current position within the graph. 
+              <div class="w-100">
+                <h2 class="breakWord">Node: <a id="parent_url" class="text-primary" target="_blank"></a></h2>
+                <svg width="100%" height="740" viewBox="0 0 740 740"></svg>
+                <h2 class="breakWord">Child: <span id="child_url"></span></h2>
+                <script id="search_json" type="application/json">{"found": "false", "children": [{"found": "false", "children": [{"found": "false", "url": "https://www.caelum.site/demo/node5", "domain": "www.caelum.site"}, {"found": "false", "url": "https://www.caelum.site/demo/node4", "domain": "www.caelum.site"}], "url": "https://www.caelum.site/demo/node2", "domain": "www.caelum.site"}, {"found": "false", "url": "https://www.caelum.site/demo/node1", "domain": "www.caelum.site"}, {"found": "false", "children": [{"found": "false", "children": [{"found": "false", "url": "https://www.caelum.site/demo/node9", "domain": "www.caelum.site"}, {"found": "false", "children": [{"found": "false", "url": "https://www.caelum.site/demo/node10", "domain": "www.caelum.site"}], "url": "https://www.caelum.site/demo/node8", "domain": "www.caelum.site"}, {"found": "false", "url": "https://www.caelum.site/demo/node7", "domain": "www.caelum.site"}], "url": "https://www.caelum.site/demo/node6", "domain": "www.caelum.site"}], "url": "https://www.caelum.site/demo/node3", "domain": "www.caelum.site"}], "url": "https://www.caelum.site/demo/node0", "domain": "www.caelum.site"}</script>
+              </div>
+
+              <p>Note how the root node0 encapsulates every other node. On the first level we see three smaller circles. These represent node1, 2 and 3. Node2 contains nodes 4 and 5, node 3 contains the node6 which in turn contains nodes down the tree. We see that leaf nodes (nodes with no children) are white while nodes at each level are colored similarly. Clicking down a path of nodes allows the user to clearly see the currently selected node (displayed as a link to that page above graph) as well as the ability to hover over nodes one level up or one level down from the current position within the graph.
               </p>
             </div>
-            
+
 
           </div>
 
@@ -89,6 +97,8 @@
   <div metal:fill-slot="additional_js">
     <script src="/static/javascript/bokeh-0.12.13.min.js"></script>
     <script src="/static/javascript/demo_graph.js"></script>
+    <script src="/static/javascript/d3.v4.min.js"></script>
+    <script src="/static/javascript/graph.js"></script>
   </div>
 
 


### PR DESCRIPTION
We could use this if we wanted to show the demo graph on the demo page instead of (or in addition to) a link to the results page of the demo graph.